### PR TITLE
change hovered color

### DIFF
--- a/flavor.toml
+++ b/flavor.toml
@@ -25,7 +25,7 @@
 cwd = { fg = "#CECDC3", bold = true } # tx
 
 # Hovered
-hovered = { bg = "#1C1B1A" } # bg-2
+hovered = { bg = "#403E3C" } # ui-3
 preview_hovered = { underline = true }
 
 # Find


### PR DESCRIPTION
The current hovered color is not disctinct from the background color and make the theme unusable. 

Change for a lighter color with more contrast.